### PR TITLE
Fix crash on enabling previously invalid zone

### DIFF
--- a/geodns.go
+++ b/geodns.go
@@ -141,8 +141,6 @@ func main() {
 	metrics := NewMetrics()
 	go metrics.Updater()
 
-	go statHatPoster()
-
 	if *flaginter == "*" {
 		addrs, _ := net.InterfaceAddrs()
 		ips := make([]string, 0)
@@ -160,6 +158,8 @@ func main() {
 	}
 
 	inter := getInterfaces()
+
+	go statHatPoster()
 
 	Zones := make(Zones)
 

--- a/geoip.go
+++ b/geoip.go
@@ -81,8 +81,9 @@ func (g *GeoIP) GetASN(ip net.IP) (asn string, netmask int) {
 }
 
 func (g *GeoIP) setDirectory() {
-	if len(Config.GeoIP.Directory) > 0 {
-		geoip.SetCustomDirectory(Config.GeoIP.Directory)
+	directory := Config.GeoIPDirectory()
+	if len(directory) > 0 {
+		geoip.SetCustomDirectory(directory)
 	}
 }
 

--- a/stathat.go
+++ b/stathat.go
@@ -12,7 +12,7 @@ import (
 
 func (zs *Zones) statHatPoster() {
 
-	if len(Config.StatHat.ApiKey) == 0 {
+	if !Config.HasStatHat() {
 		return
 	}
 
@@ -40,17 +40,17 @@ func (zs *Zones) statHatPoster() {
 
 				apiKey := zone.Logging.StatHatAPI
 				if len(apiKey) == 0 {
-					apiKey = Config.StatHat.ApiKey
+					apiKey = Config.StatHatApiKey()
 				}
 				if len(apiKey) == 0 {
 					continue
 				}
-				stathat.PostEZCount("zone "+name+" queries~"+suffix, Config.StatHat.ApiKey, int(newCount))
+				stathat.PostEZCount("zone "+name+" queries~"+suffix, Config.StatHatApiKey(), int(newCount))
 
 				ednsCount := zone.Metrics.EdnsQueries.Count()
 				newEdnsCount := ednsCount - lastEdnsCounts[name]
 				lastEdnsCounts[name] = ednsCount
-				stathat.PostEZCount("zone "+name+" edns queries~"+suffix, Config.StatHat.ApiKey, int(newEdnsCount))
+				stathat.PostEZCount("zone "+name+" edns queries~"+suffix, Config.StatHatApiKey(), int(newEdnsCount))
 
 			}
 		}
@@ -68,7 +68,7 @@ func statHatPoster() {
 	for {
 		time.Sleep(60 * time.Second)
 
-		if !Config.Flags.HasStatHat {
+		if !Config.HasStatHat() {
 			log.Println("No stathat configuration")
 			continue
 		}
@@ -79,8 +79,8 @@ func statHatPoster() {
 		newQueries := current - lastQueryCount
 		lastQueryCount = current
 
-		stathat.PostEZCount("queries~"+suffix, Config.StatHat.ApiKey, int(newQueries))
-		stathat.PostEZValue("goroutines "+serverID, Config.StatHat.ApiKey, float64(runtime.NumGoroutine()))
+		stathat.PostEZCount("queries~"+suffix, Config.StatHatApiKey(), int(newQueries))
+		stathat.PostEZValue("goroutines "+serverID, Config.StatHatApiKey(), float64(runtime.NumGoroutine()))
 
 	}
 }

--- a/zone.go
+++ b/zone.go
@@ -80,12 +80,19 @@ func NewZone(name string) *Zone {
 func (z *Zone) SetupMetrics(old *Zone) {
 	if old != nil {
 		z.Metrics = old.Metrics
-	} else {
+	}
+	if z.Metrics.Queries == nil {
 		z.Metrics.Queries = metrics.NewMeter()
-		z.Metrics.EdnsQueries = metrics.NewMeter()
 		metrics.Register(z.Origin+" queries", z.Metrics.Queries)
+	}
+	if z.Metrics.EdnsQueries == nil {
+		z.Metrics.EdnsQueries = metrics.NewMeter()
 		metrics.Register(z.Origin+" EDNS queries", z.Metrics.EdnsQueries)
+	}
+	if z.Metrics.LabelStats == nil {
 		z.Metrics.LabelStats = NewZoneLabelStats(10000)
+	}
+	if z.Metrics.ClientStats == nil {
 		z.Metrics.ClientStats = NewZoneLabelStats(10000)
 	}
 }

--- a/zone.go
+++ b/zone.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"strings"
-	"time"
 
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/rcrowley/go-metrics"
@@ -58,7 +57,6 @@ type Zone struct {
 	LabelCount int
 	Options    ZoneOptions
 	Logging    *ZoneLogging
-	LastRead   time.Time
 	Metrics    ZoneMetrics
 }
 

--- a/zone.go
+++ b/zone.go
@@ -93,8 +93,12 @@ func (z *Zone) SetupMetrics(old *Zone) {
 func (z *Zone) Close() {
 	metrics.Unregister(z.Origin + " queries")
 	metrics.Unregister(z.Origin + " EDNS queries")
-	z.Metrics.LabelStats.Close()
-	z.Metrics.ClientStats.Close()
+	if z.Metrics.LabelStats != nil {
+		z.Metrics.LabelStats.Close()
+	}
+	if z.Metrics.ClientStats != nil {
+		z.Metrics.ClientStats.Close()
+	}
 }
 
 func (l *Label) firstRR(dnsType uint16) dns.RR {

--- a/zone_test.go
+++ b/zone_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func (s *ConfigSuite) TestExampleComZone(c *C) {
-	ex := s.zones["test.example.com"]
+	ex, ok := s.zones["test.example.com"]
+
+	c.Check(ok, Equals, true)
+	c.Check(ex, NotNil)
 
 	// test.example.com was loaded
 	c.Assert(ex.Labels, NotNil)

--- a/zones.go
+++ b/zones.go
@@ -21,6 +21,8 @@ import (
 // Zones maps domain names to zone data
 type Zones map[string]*Zone
 
+var lastRead = map[string]time.Time{}
+
 func zonesReader(dirName string, zones Zones) {
 	for {
 		zonesReadDir(dirName, zones)
@@ -56,12 +58,14 @@ func zonesReadDir(dirName string, zones Zones) error {
 
 		seenZones[zoneName] = true
 
-		if zone, ok := zones[zoneName]; !ok || file.ModTime().After(zone.LastRead) {
+		if _, ok := lastRead[zoneName]; !ok || file.ModTime().After(lastRead[zoneName]) {
 			if ok {
 				logPrintf("Reloading %s\n", fileName)
 			} else {
 				logPrintf("Reading new file %s\n", fileName)
 			}
+
+			lastRead[zoneName] = file.ModTime()
 
 			//log.Println("FILE:", i, file, zoneName)
 			config, err := readZoneFile(zoneName, path.Join(dirName, fileName))
@@ -70,7 +74,6 @@ func zonesReadDir(dirName string, zones Zones) error {
 				log.Println(parseErr.Error())
 				continue
 			}
-			config.LastRead = file.ModTime()
 
 			addHandler(zones, zoneName, config)
 		}
@@ -84,6 +87,7 @@ func zonesReadDir(dirName string, zones Zones) error {
 			continue
 		}
 		log.Println("Removing zone", zone.Origin)
+		delete(lastRead, zoneName)
 		zone.Close()
 		dns.HandleRemove(zoneName)
 		delete(zones, zoneName)

--- a/zones_test.go
+++ b/zones_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	. "github.com/abh/geodns/Godeps/_workspace/src/gopkg.in/check.v1"
@@ -21,6 +22,7 @@ var _ = Suite(&ConfigSuite{})
 
 func (s *ConfigSuite) SetUpSuite(c *C) {
 	s.zones = make(Zones)
+	lastRead = map[string]time.Time{}
 	zonesReadDir("dns", s.zones)
 }
 


### PR DESCRIPTION
Fix issue #74 

This crash is similar to #69 but with a different cause (and different fix)

To replicate:
* Alter `dns/example.com` so it is invalid (e.g. put an `x` at the top)
* Start `geodns`
* Alter `dns/example.com` so it is valid (e.g. remove the inserted `x`)
* Wait for `geodns` to reload `example.com`
* Perform any `dig` query for that zone e.g. to `dig A weight.example.com @....`

This produces a panic at:

    	z.Metrics.Queries.Mark(1)

on line 34 of `zone.go`, because z.Metrics is `{nil, nil, nil, nil}`.

This cause of this problem is that when the zone is first loaded, `Metrics` is initialised to `{nil, nil, nil, nil}`. `SetupMetrics` is never called because the zone is invalid, but the old zone is kept around (presumably because in more complex circumstances it could have useful metrics in which should not be zeroed. When the zone is made loadable, `old` is non-nil, so the previous `Metrics` `struct` is copied, but not initialised, so it remains `nil`. The fix (coming right up) is to initialise any `nil` members of the `Metrics` struct whatever the value of `old` on entry.
