### PR TITLE
Add a health RR

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,16 @@ type AppConfig struct {
 		User     string
 		Password string
 	}
+	Nodeping struct {
+		Token string
+	}
+	Pingdom struct {
+		Username     string
+		Password     string
+		AccountEmail string
+		AppKey       string
+		StateMap     string
+	}
 }
 
 var Config = new(AppConfig)

--- a/healthtest.go
+++ b/healthtest.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"fmt"
+	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
+	"log"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+)
+
+var (
+	healthQtypes = []uint16{dns.TypeA, dns.TypeAAAA}
+)
+
+type HealthTester interface {
+	Test(ht *HealthTest) bool
+	String() string
+}
+
+type HealthTestParameters struct {
+	frequency        time.Duration
+	retryTime        time.Duration
+	timeout          time.Duration
+	retries          int
+	healthyInitially bool
+	testName         string
+	global           bool
+}
+
+type HealthTest struct {
+	HealthTestParameters
+	ipAddress    net.IP
+	healthy      bool
+	healthyMutex sync.RWMutex
+	closing      chan chan error
+	health       chan bool
+	tester       *HealthTester
+	globalMap    map[string]bool
+}
+
+type HealthTestRunnerEntry struct {
+	HealthTest
+	references map[string]bool
+}
+
+type HealthTestRunner struct {
+	entries    map[string]*HealthTestRunnerEntry
+	entryMutex sync.RWMutex
+}
+
+var healthTestRunner = &HealthTestRunner{
+	entries: make(map[string]*HealthTestRunnerEntry),
+}
+
+func defaultHealthTestParameters() HealthTestParameters {
+	return HealthTestParameters{
+		frequency:        30 * time.Second,
+		retryTime:        5 * time.Second,
+		timeout:          5 * time.Second,
+		retries:          3,
+		healthyInitially: false,
+	}
+}
+
+func newHealthTest(ipAddress net.IP, htp HealthTestParameters, tester *HealthTester) *HealthTest {
+	ht := HealthTest{
+		ipAddress:            ipAddress,
+		HealthTestParameters: htp,
+		healthy:              true,
+		tester:               tester,
+		globalMap:            make(map[string]bool),
+	}
+	ht.healthy = ht.healthyInitially
+	if ht.frequency < time.Second {
+		ht.frequency = time.Second
+	}
+	if ht.retryTime < time.Second {
+		ht.retryTime = time.Second
+	}
+	if ht.timeout < time.Second {
+		ht.timeout = time.Second
+	}
+	return &ht
+}
+
+// Format the health test as a string - used to compare two tests and as an index for the hash
+func (ht *HealthTest) String() string {
+	ip := ht.ipAddress.String()
+	if ht.HealthTestParameters.global {
+		ip = "" // ensure we have a single instance of a global health check with the same paramaters
+	}
+	return fmt.Sprintf("%s/%v/%s", ip, ht.HealthTestParameters, (*ht.tester).String())
+}
+
+// safe copy function that copies the parameters but not (e.g.) the
+// mutex
+func (ht *HealthTest) copy(ipAddress net.IP) *HealthTest {
+	return newHealthTest(ipAddress, ht.HealthTestParameters, ht.tester)
+}
+
+func (ht *HealthTest) setGlobal(g map[string]bool) {
+	ht.healthyMutex.Lock()
+	defer ht.healthyMutex.Unlock()
+	ht.globalMap = g
+}
+
+func (ht *HealthTest) getGlobal(k string) (bool, bool) {
+	ht.healthyMutex.RLock()
+	defer ht.healthyMutex.RUnlock()
+	healthy, ok := ht.globalMap[k]
+	return healthy, ok
+}
+
+func (ht *HealthTest) run() {
+	randomDelay := rand.Int63n(ht.frequency.Nanoseconds())
+	if !ht.isHealthy() {
+		randomDelay = rand.Int63n(ht.retryTime.Nanoseconds())
+	}
+	var nextPoll time.Time = time.Now().Add(time.Duration(randomDelay))
+	var pollStart time.Time
+	failCount := 0
+	for {
+		var pollDelay time.Duration
+		if now := time.Now(); nextPoll.After(now) {
+			pollDelay = nextPoll.Sub(now)
+		}
+		var startPoll <-chan time.Time
+		var closingPoll <-chan chan error
+		if pollStart.IsZero() {
+			closingPoll = ht.closing
+			startPoll = time.After(pollDelay)
+		}
+		select {
+		case errc := <-closingPoll: // don't close while we are polling or we send to a closed channel
+			errc <- nil
+			return
+		case <-startPoll:
+			pollStart = time.Now()
+			go ht.poll()
+		case h := <-ht.health:
+			nextPoll = pollStart.Add(ht.frequency)
+			if h {
+				ht.setHealthy(true)
+				failCount = 0
+			} else {
+				failCount++
+				logPrintf("Failure for %s, retry count=%d, healthy=%v", ht.ipAddress, failCount, ht.isHealthy())
+				if failCount >= ht.retries {
+					ht.setHealthy(false)
+					nextPoll = pollStart.Add(ht.retryTime)
+				}
+			}
+			pollStart = time.Time{}
+			logPrintf("Check result for %s health=%v, next poll at %s", ht.ipAddress, h, nextPoll)
+			//randomDelay := rand.Int63n(time.Second.Nanoseconds())
+			//nextPoll = nextPoll.Add(time.Duration(randomDelay))
+		}
+	}
+}
+
+func (ht *HealthTest) poll() {
+	logPrintf("Checking health of %s", ht.ipAddress)
+	result := (*ht.tester).Test(ht)
+	logPrintf("Checked health of %s, healthy=%v", ht.ipAddress, result)
+	ht.health <- result
+}
+
+func (ht *HealthTest) start() {
+	ht.closing = make(chan chan error)
+	ht.health = make(chan bool)
+	logPrintf("Starting health test on %s, frequency=%s, retry_time=%s, timeout=%s, retries=%d", ht.ipAddress, ht.frequency, ht.retryTime, ht.timeout, ht.retries)
+	go ht.run()
+}
+
+func (ht *HealthTest) stop() (err error) {
+	// Check it's been started by existing of the closing channel
+	if ht.closing == nil {
+		return nil
+	}
+	logPrintf("Stopping health test on %s", ht.ipAddress)
+	errc := make(chan error)
+	ht.closing <- errc
+	err = <-errc
+	close(ht.closing)
+	ht.closing = nil
+	close(ht.health)
+	ht.health = nil
+	return err
+}
+
+func (ht *HealthTest) isHealthy() bool {
+	ht.healthyMutex.RLock()
+	h := ht.healthy
+	ht.healthyMutex.RUnlock()
+	return h
+}
+
+func (ht *HealthTest) setHealthy(h bool) {
+	ht.healthyMutex.Lock()
+	old := ht.healthy
+	ht.healthy = h
+	ht.healthyMutex.Unlock()
+	if old != h {
+		logPrintf("Changing health status of %s from %v to %v", ht.ipAddress, old, h)
+	}
+}
+
+func (htr *HealthTestRunner) addTest(ht *HealthTest, ref string) {
+	key := ht.String()
+	htr.entryMutex.Lock()
+	defer htr.entryMutex.Unlock()
+	if t, ok := htr.entries[key]; ok {
+		// we already have an instance of this test running. Record we are using it
+		t.references[ref] = true
+	} else {
+		// a test that isn't running. Record we are using it and start the test
+		t := &HealthTestRunnerEntry{
+			HealthTest: *ht.copy(ht.ipAddress),
+			references: make(map[string]bool),
+		}
+		if t.global {
+			t.ipAddress = nil
+		}
+		// we know it is not started, so no need for the mutex
+		t.healthy = ht.healthy
+		t.references[ref] = true
+		t.start()
+		htr.entries[key] = t
+	}
+}
+
+func (htr *HealthTestRunner) removeTest(ht *HealthTest, ref string) {
+	key := ht.String()
+	htr.entryMutex.Lock()
+	defer htr.entryMutex.Unlock()
+	if t, ok := htr.entries[key]; ok {
+		delete(t.references, ref)
+		// record the last state of health
+		ht.healthyMutex.Lock()
+		ht.healthy = t.isHealthy()
+		ht.healthyMutex.Unlock()
+		if len(t.references) == 0 {
+			// no more references, delete the test
+			t.stop()
+			delete(htr.entries, key)
+		}
+	}
+}
+
+func (htr *HealthTestRunner) refAllGlobalHealthChecks(ref string, add bool) {
+	htr.entryMutex.Lock()
+	defer htr.entryMutex.Unlock()
+	for key, t := range htr.entries {
+		if t.global {
+			if add {
+				t.references[ref] = true
+			} else {
+				delete(t.references, ref)
+				if len(t.references) == 0 {
+					// no more references, delete the test
+					t.stop()
+					delete(htr.entries, key)
+				}
+			}
+		}
+	}
+}
+
+func (htr *HealthTestRunner) isHealthy(ht *HealthTest) bool {
+	key := ht.String()
+	htr.entryMutex.RLock()
+	defer htr.entryMutex.RUnlock()
+	if t, ok := htr.entries[key]; ok {
+		if t.global {
+			healthy, ok := t.getGlobal(ht.ipAddress.String())
+			if ok {
+				return healthy
+			}
+		} else {
+			return t.isHealthy()
+		}
+	}
+	return ht.isHealthy()
+}
+
+func (z *Zone) newHealthTest(l *Label, data interface{}) {
+	// First safely get rid of any old test. As label tests
+	// should never run this should never be executed
+	if l.Test != nil {
+		l.Test.stop()
+		l.Test = nil
+	}
+
+	if data == nil {
+		return
+	}
+	if i, ok := data.(map[string]interface{}); ok {
+		if t, ok := i["type"]; ok {
+			ts := valueToString(t)
+			htp := defaultHealthTestParameters()
+			if nh, ok := HealthTesterMap[ts]; !ok {
+				log.Printf("Bad health test type '%s'", ts)
+			} else {
+				htp.testName = ts
+				h := nh(i, &htp)
+
+				for k, v := range i {
+					switch k {
+					case "frequency":
+						htp.frequency = time.Duration(valueToInt(v)) * time.Second
+					case "retry_time":
+						htp.retryTime = time.Duration(valueToInt(v)) * time.Second
+					case "timeout":
+						htp.retryTime = time.Duration(valueToInt(v)) * time.Second
+					case "retries":
+						htp.retries = valueToInt(v)
+					case "healthy_initially":
+						htp.healthyInitially = valueToBool(v)
+						logPrintf("HealthyInitially for %s is %v", l.Label, htp.healthyInitially)
+					}
+				}
+
+				l.Test = newHealthTest(nil, htp, &h)
+			}
+		}
+	}
+}
+
+func (z *Zone) StartStopHealthChecks(start bool, oldZone *Zone) {
+	logPrintf("Start/stop health checks on zone %s start=%v", z.Origin, start)
+	for labelName, label := range z.Labels {
+		for _, qtype := range healthQtypes {
+			if label.Records[qtype] != nil && len(label.Records[qtype]) > 0 {
+				for i := range label.Records[qtype] {
+					rr := label.Records[qtype][i].RR
+					var ip net.IP
+					switch rrt := rr.(type) {
+					case *dns.A:
+						ip = rrt.A
+					case *dns.AAAA:
+						ip = rrt.AAAA
+					default:
+						continue
+					}
+					var test *HealthTest
+					ref := fmt.Sprintf("%s/%s/%d/%d", z.Origin, labelName, qtype, i)
+					if start {
+						if test = label.Records[qtype][i].Test; test != nil {
+							// stop any old test
+							healthTestRunner.removeTest(test, ref)
+						} else {
+							if ltest := label.Test; ltest != nil {
+								test = ltest.copy(ip)
+								label.Records[qtype][i].Test = test
+							}
+						}
+						if test != nil {
+							test.ipAddress = ip
+							// if we are given an oldzone, let's see if we can find the old RR and
+							// copy over the initial health state, rather than use the initial health
+							// state provided from the label. This helps to stop health state bouncing
+							// when a zone file is reloaded for a purposes unrelated to the RR
+							if oldZone != nil {
+								oLabel, ok := oldZone.Labels[labelName]
+								if ok {
+									if oLabel.Test != nil {
+										for i := range oLabel.Records[qtype] {
+											oRecord := oLabel.Records[qtype][i]
+											var oip net.IP
+											switch orrt := oRecord.RR.(type) {
+											case *dns.A:
+												oip = orrt.A
+											case *dns.AAAA:
+												oip = orrt.AAAA
+											default:
+												continue
+											}
+											if oip.Equal(ip) {
+												if oRecord.Test != nil {
+													h := oRecord.Test.isHealthy()
+													logPrintf("Carrying over previous health state for %s: %v", oRecord.Test.ipAddress, h)
+													// we know the test is stopped (as we haven't started it) so we can write
+													// without the mutex and avoid a misleading log message
+													test.healthy = h
+												}
+												break
+											}
+										}
+									}
+								}
+							}
+							healthTestRunner.addTest(test, ref)
+						}
+					} else {
+						if test = label.Records[qtype][i].Test; test != nil {
+							healthTestRunner.removeTest(test, ref)
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/healthtesters.go
+++ b/healthtesters.go
@@ -1,0 +1,561 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+/*
+ * Each HealthTester is a struct that implements the HealthTester interface. To do so it
+ * needs to provide three functions:
+ *
+ * func (m *MyHealthTester) Test(ht *HealthTest) bool
+ *
+ *   performs the test in question and returns a bool if it is up
+ *
+ * func (m *MyHealthTester) String() string
+ *
+ *   returns a string which contains all the paramaters within the struct that are important
+ *   for uniqueness. This is normally a call to fmt.Sprintf.
+ *
+ * func newMyHealthTester(params map[string]interface{}) HealthTester, bool
+ *
+ *   create a new health tester of type myHealthTester with parameters in params. Second
+ *   return value true if it is global (i.e. one test yields results for all IP addresses)
+ *
+ * Then add a single entry to the HealthTesterTypes map pointing to the third function
+ */
+
+var HealthTesterMap = map[string]func(params map[string]interface{}, htp *HealthTestParameters) HealthTester{
+	"tcp":      newTcpHealthTester,
+	"ntp":      newNtpHealthTester,
+	"exec":     newExecHealthTester,
+	"file":     newFileHealthTester,
+	"nodeping": newNodepingHealthTester,
+	"pingdom":  newPingdomHealthTester,
+}
+
+// TcpHealthTester tests that a port is open
+//
+// Parameters:
+//   port (integer): the port to test
+
+type TcpHealthTester struct {
+	port int
+}
+
+func (t *TcpHealthTester) Test(ht *HealthTest) bool {
+	if conn, err := net.DialTimeout("tcp", net.JoinHostPort(ht.ipAddress.String(), strconv.Itoa(t.port)), ht.timeout); err != nil {
+		return false
+	} else {
+		conn.Close()
+	}
+	return true
+}
+
+func (t *TcpHealthTester) String() string {
+	return fmt.Sprintf("%d", t.port)
+}
+
+func newTcpHealthTester(params map[string]interface{}, htp *HealthTestParameters) HealthTester {
+	port := 80
+	if v, ok := params["port"]; ok {
+		port = valueToInt(v)
+	}
+	return &TcpHealthTester{port: port}
+}
+
+// NtpHealthTester tests that NTP is running and is less than or equal to a given NTP Stratum
+//
+// Parameters:
+//   max_stratum (integer): the maximum permissible NTP stratum
+
+type NtpHealthTester struct {
+	maxStratum int
+}
+
+func (t *NtpHealthTester) Test(ht *HealthTest) bool {
+	udpAddress, err := net.ResolveUDPAddr("udp", net.JoinHostPort(ht.ipAddress.String(), "123"))
+	if err != nil {
+		return false
+	}
+
+	data := make([]byte, 48)
+	data[0] = 4<<3 | 3 /* version 4, client mode */
+
+	conn, err := net.DialUDP("udp", nil, udpAddress)
+	if err != nil {
+		return false
+	}
+
+	defer conn.Close()
+
+	_, err = conn.Write(data)
+	if err != nil {
+		return false
+	}
+
+	conn.SetDeadline(time.Now().Add(ht.timeout))
+
+	_, err = conn.Read(data)
+	if err != nil {
+		return false
+	}
+
+	stratum := data[1]
+
+	if stratum == 0 || stratum > byte(t.maxStratum) {
+		return false
+	}
+
+	return true
+}
+
+func (t *NtpHealthTester) String() string {
+	return fmt.Sprintf("%d", t.maxStratum)
+}
+
+func newNtpHealthTester(params map[string]interface{}, htp *HealthTestParameters) HealthTester {
+	maxStratum := 3
+	if v, ok := params["max_stratum"]; ok {
+		maxStratum = valueToInt(v)
+	}
+	return &NtpHealthTester{maxStratum: maxStratum}
+}
+
+// ExecHealthTester tests that an external program runs with a zero exit code
+//
+// Parameters:
+//   cmd (string): path to the external program plus space-separated parameters
+//
+// A {} in the command is substituted with the IP to test
+
+type ExecHealthTester struct {
+	cmd string
+}
+
+func (t *ExecHealthTester) Test(ht *HealthTest) bool {
+	commandSlice := strings.Split(strings.Replace(t.cmd, "{}", ht.ipAddress.String(), -1), " ")
+	cmd := exec.Command(commandSlice[0], commandSlice[1:]...)
+	return cmd.Run() == nil
+}
+
+func (t *ExecHealthTester) String() string {
+	return fmt.Sprintf("%s", t.cmd)
+}
+
+func newExecHealthTester(params map[string]interface{}, htp *HealthTestParameters) HealthTester {
+	cmd := "echo '%s'"
+	if v, ok := params["cmd"]; ok {
+		cmd = valueToString(v)
+	}
+	return &ExecHealthTester{cmd: cmd}
+}
+
+// FileHealthTester reads health of IP addresses from an external JSON map
+//
+// Parameters:
+//   path (string): path to the JSON file
+//
+// The JSON file is of the format:
+//
+//     {
+//       "192.200.0.1": true,
+//       "192.200.0.2": false
+//     }
+
+type FileHealthTester struct {
+	path         string
+	lastHash     string
+	lastReadTime time.Time
+}
+
+func (t *FileHealthTester) Test(ht *HealthTest) bool {
+	if len(t.path) == 0 {
+		logPrintf("No test file path specified")
+		return false
+	}
+
+	if file, err := os.Open(t.path); err != nil {
+		log.Printf("Cannot open test file '%s': %v", t.path, err)
+		return false
+	} else {
+		defer file.Close()
+		if stat, err := file.Stat(); err != nil {
+			log.Printf("Cannot stat test file '%s': %v", t.path, err)
+			return false
+		} else {
+			modTime := stat.ModTime()
+			if modTime == t.lastReadTime {
+				return true
+			}
+			if bytes, err := ioutil.ReadAll(file); err != nil {
+				log.Printf("Cannot read test file '%s': %v", t.path, err)
+				return false
+			} else {
+				t.lastReadTime = modTime
+
+				hasher := sha256.New()
+				hasher.Write(bytes)
+				hash := hex.EncodeToString(hasher.Sum(nil))
+				if hash == t.lastHash {
+					return true
+				}
+				t.lastHash = hash
+
+				var m map[string]bool
+				if err := json.Unmarshal(bytes, &m); err != nil {
+					log.Printf("Cannot parse test file '%s': %v", t.path, err)
+					return false
+				}
+				ht.setGlobal(m)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (t *FileHealthTester) String() string {
+	return fmt.Sprintf("%s", t.path)
+}
+
+func newFileHealthTester(params map[string]interface{}, htp *HealthTestParameters) HealthTester {
+	var path string
+	if v, ok := params["path"]; ok {
+		path = valueToString(v)
+	}
+	htp.global = true
+	return &FileHealthTester{path: path}
+}
+
+// NodepingHealthTester reads health of IP addresses from an external Nodeping service
+//
+// The label of each test must correspond to the IP address being tested
+//
+// Parameters:
+//   token (string): API key token to use with nodeping service
+//
+// If the token is not specified it defaults to the token within the [nodeping] section of the config file
+
+type NodepingHealthTester struct {
+	token string
+}
+
+/* Response is of the form below - only down sites are mentioned
+{
+   "201511111111111-AAAAAAAAA" : {
+      "_id" : "201511111111111-AAAAAAAAA-11111111111",
+      "label" : "192.200.0.1",
+      "type" : "down",
+      "message" : "Error: connect ECONNREFUSED",
+      "t" : 14141414141414
+   }
+}
+*/
+
+func (t *NodepingHealthTester) Test(ht *HealthTest) bool {
+	token := t.token
+	if len(token) == 0 {
+		cfgMutex.RLock()
+		token = Config.Nodeping.Token
+		cfgMutex.RUnlock()
+		if len(token) == 0 {
+			logPrintf("No Nodeping API key specified")
+			return false
+		}
+	}
+
+	var vals url.Values = url.Values{}
+	vals.Set("token", token)
+	u := url.URL{
+		Host:   "api.nodeping.com",
+		Scheme: "https",
+		Path:   "/api/1/results/current",
+	}
+	u.RawQuery = vals.Encode()
+	if resp, err := http.Get(u.String()); err != nil {
+		log.Printf("Cannot access Nodeping API : %v", err)
+		return false
+	} else {
+		defer resp.Body.Close()
+		if bytes, err := ioutil.ReadAll(resp.Body); err != nil {
+			log.Printf("Cannot read from Nodeping API: %v", err)
+			return false
+		} else {
+			var m map[string]interface{}
+			if err := json.Unmarshal(bytes, &m); err != nil {
+				log.Printf("Cannot parse response from Nodeping API: %v", err)
+				return false
+			}
+
+			state := make(map[string]bool)
+			for _, item := range m {
+				if result, ok := item.(map[string]interface{}); ok {
+					if ip, ok := result["label"]; ok {
+						host := valueToString(ip)
+						logPrintf("Nodeping host %s health set to false", host)
+						state[host] = false // only down or disabled events reported
+					}
+				}
+			}
+
+			ht.setGlobal(state)
+			return true
+		}
+
+	}
+	return false
+}
+
+func (t *NodepingHealthTester) String() string {
+	return fmt.Sprintf("%s", t.token)
+}
+
+func newNodepingHealthTester(params map[string]interface{}, htp *HealthTestParameters) HealthTester {
+	var token string
+	if v, ok := params["token"]; ok {
+		token = valueToString(v)
+	}
+	// as we can only detect down nodes, not all nodes, we should assume the default is health
+	htp.healthyInitially = true
+	htp.global = true
+	return &NodepingHealthTester{token: token}
+}
+
+// PingdomHealthTester reads health of IP addresses from an external Pingdom service
+//
+// The name of each test must correspond to the IP address being tested
+//
+// Parameters:
+//   username (string): username to use with Pingdom service
+//   password (string): password to use with the Pingdom service
+//   account_email (string, optional): account email to use with Pingdom service (multi user accounts only)
+//   app_key (string, optional): application key to use with the Pingdom service (has a sensible default)
+//   state_map (map, optional): map of Pingdom status to health values (e.g. true/false)
+//
+// If any of the above are not specified, they default to the following fields within the [pingdom] section of the config file:
+// 		username
+//		password
+//		accountemail
+//		appkey
+//		statemap
+//
+// The stateMap parameter is optional and normally not required. It defaults to:
+//    { "up": true, "down": false, "paused": false}
+// which means 'up' corresponds to healthy, 'down' and 'paused' to unhealthy, and the remainder to the default value.
+//
+// To include 'unconfirmed_down' as unhealthy as well, one would use:
+//    { "up": true, "down": false, "paused": false, "unconfirmed_down", false}
+//
+
+type PingdomHealthTester struct {
+	username     string
+	password     string
+	accountEmail string
+	appKey       string
+	stateMap     map[string]bool
+}
+
+/* Response is of the form below
+
+{
+    "checks": [
+        {
+            "hostname": "example.com",
+            "id": 85975,
+            "lasterrortime": 1297446423,
+            "lastresponsetime": 355,
+            "lasttesttime": 1300977363,
+            "name": "My check 1",
+            "resolution": 1,
+            "status": "up",
+            "type": "http",
+            "tags": [
+                {
+                    "name": "apache",
+                    "type": "a",
+                    "count": 2
+                }
+            ]
+        },
+        ...
+    ]
+}
+*/
+
+func (t *PingdomHealthTester) Test(ht *HealthTest) bool {
+	username := t.username
+	if len(username) == 0 {
+		cfgMutex.RLock()
+		username = Config.Pingdom.Username
+		cfgMutex.RUnlock()
+		if len(username) == 0 {
+			logPrintf("No Pingdom username specified")
+			return false
+		}
+	}
+
+	password := t.password
+	if len(password) == 0 {
+		cfgMutex.RLock()
+		password = Config.Pingdom.Password
+		cfgMutex.RUnlock()
+		if len(password) == 0 {
+			logPrintf("No Pingdom password specified")
+			return false
+		}
+	}
+
+	accountEmail := t.accountEmail
+	if len(accountEmail) == 0 {
+		cfgMutex.RLock()
+		accountEmail = Config.Pingdom.AccountEmail
+		cfgMutex.RUnlock()
+	}
+
+	appKey := t.appKey
+	if len(appKey) == 0 {
+		cfgMutex.RLock()
+		appKey = Config.Pingdom.AppKey
+		cfgMutex.RUnlock()
+		if len(appKey) == 0 {
+			appKey = "gyxtnd2fzco8ys29m8luk4syag4ybmc0"
+		}
+	}
+
+	stateMap := t.stateMap
+	if stateMap == nil {
+		cfgMutex.RLock()
+		stateMapString := Config.Pingdom.StateMap
+		cfgMutex.RUnlock()
+		if len(stateMapString) > 0 {
+			stateMap = make(map[string]bool)
+			if err := json.Unmarshal([]byte(stateMapString), &stateMap); err != nil {
+				logPrintf("Cannot decode configfile Pingdom state map JSON")
+				return false
+			}
+		}
+		if stateMap == nil {
+			stateMap = defaultPingdomStateMap
+		}
+	}
+
+	var vals url.Values = url.Values{}
+	u := url.URL{
+		Host:   "api.pingdom.com",
+		Scheme: "https",
+		Path:   "/api/2.0/checks",
+	}
+	u.RawQuery = vals.Encode()
+
+	client := &http.Client{}
+
+	if req, err := http.NewRequest("GET", u.String(), nil); err != nil {
+		log.Printf("Cannot construct Pingdom API request: %v", err)
+	} else {
+		req.SetBasicAuth(username, password)
+		if len(accountEmail) > 0 {
+			req.Header.Add("Account-Email", accountEmail)
+		}
+		req.Header.Add("App-Key", appKey)
+		if resp, err := client.Do(req); err != nil {
+			log.Printf("Cannot access Pingdom API : %v", err)
+			return false
+		} else {
+			defer resp.Body.Close()
+			if bytes, err := ioutil.ReadAll(resp.Body); err != nil {
+				log.Printf("Cannot read from Pingdom API: %v", err)
+				return false
+			} else {
+				var m map[string]interface{}
+				if err := json.Unmarshal(bytes, &m); err != nil {
+					log.Printf("Cannot parse response from Pingdom API: %v", err)
+					return false
+				}
+				if checks, ok := m["checks"]; !ok {
+					log.Printf("Cannot parse response from Pingdom API check response")
+					return false
+				} else {
+					if checkarray, ok := checks.([]interface{}); !ok {
+						log.Printf("Cannot parse response from Pingdom API check array: %T", checks)
+						return false
+					} else {
+						state := make(map[string]bool)
+						for _, checki := range checkarray {
+							if check, ok := checki.(map[string]interface{}); ok {
+								if ip, ok := check["name"]; ok {
+									if status, ok := check["status"]; ok {
+										s := valueToString(status)
+										if updown, ok := stateMap[s]; ok {
+											host := valueToString(ip)
+											state[host] = updown
+											logPrintf("Pingdom host %s state %s health set to %v", host, s, updown)
+										}
+									}
+								}
+							}
+						}
+
+						ht.setGlobal(state)
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (t *PingdomHealthTester) String() string {
+	return fmt.Sprintf("%s/%s/%s/%s/%v", t.username, t.password, t.accountEmail, t.appKey, t.stateMap)
+}
+
+var defaultPingdomStateMap = map[string]bool{
+	"up":     true,
+	"down":   false,
+	"paused": false,
+	// other states, i.e. unconfirmed_down, paused, are determined by initially_healthy
+}
+
+func newPingdomHealthTester(params map[string]interface{}, htp *HealthTestParameters) HealthTester {
+	var username string
+	var password string
+	var accountEmail string
+	var appKey string
+	var stateMap map[string]bool = nil
+	if v, ok := params["username"]; ok {
+		username = valueToString(v)
+	}
+	if v, ok := params["password"]; ok {
+		password = valueToString(v)
+	}
+	if v, ok := params["account_email"]; ok {
+		accountEmail = valueToString(v)
+	}
+	if v, ok := params["app_key"]; ok {
+		appKey = valueToString(v)
+	}
+	if v, ok := params["state_map"]; ok {
+		if vv, ok := v.(map[string]interface{}); ok {
+			stateMap = make(map[string]bool)
+			for k, s := range vv {
+				stateMap[valueToString(k)] = valueToBool(s)
+			}
+		}
+	}
+	htp.global = true
+	return &PingdomHealthTester{username: username, password: password, accountEmail: accountEmail, appKey: appKey, stateMap: stateMap}
+}

--- a/picker.go
+++ b/picker.go
@@ -6,13 +6,13 @@ import (
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 )
 
-func (label *Label) Picker(qtype uint16, max int) Records {
+func (label *Label) Picker(qtype uint16, max int, location *Location) Records {
 
 	if qtype == dns.TypeANY {
 		var result []Record
 		for rtype := range label.Records {
 
-			rtypeRecords := label.Picker(rtype, max)
+			rtypeRecords := label.Picker(rtype, max, location)
 
 			tmpResult := make(Records, len(result)+len(rtypeRecords))
 
@@ -44,6 +44,59 @@ func (label *Label) Picker(qtype uint16, max int) Records {
 		copy(servers, labelRR)
 		result := make([]Record, max)
 		sum := label.Weight[qtype]
+
+		// Find the distance to each server, and find the servers that are
+		// closer to the querier than the max'th furthest server, or within
+		// 5% thereof. What this means in practice is that if we have a nearby
+		// cluster of servers that are close, they all get included, so load
+		// balancing works
+		if qtype == dns.TypeA && location != nil && max < rrCount {
+			// First we record the distance to each server
+			distances := make([]float64, rrCount)
+			for i, s := range servers {
+				distance := location.Distance(s.Loc)
+				distances[i] = distance
+			}
+
+			// though this looks like O(n^2), typically max is small (e.g. 2)
+			// servers often have the same geographic location
+			// and rrCount is pretty small too, so the gain of an
+			// O(n log n) sort is small.
+			chosen := 0
+			choose := make([]bool, rrCount)
+
+			for chosen < max {
+				// Determine the minimum distance of servers not yet chosen
+				minDist := location.MaxDistance()
+				for i, _ := range servers {
+					if !choose[i] && distances[i] <= minDist {
+						minDist = distances[i]
+					}
+				}
+				// The threshold for inclusion on the this pass is 5% more
+				// than the minimum distance
+				minDist = minDist * 1.05
+				// Choose all the servers within the distance
+				for i := range servers {
+					if !choose[i] && distances[i] <= minDist {
+						choose[i] = true
+						chosen++
+					}
+				}
+			}
+
+			// Now choose only the chosen servers, using filtering without allocation
+			// slice trick. Meanwhile recalculate the total weight
+			tmpServers := servers[:0]
+			sum = 0
+			for i, s := range servers {
+				if choose[i] {
+					tmpServers = append(tmpServers, s)
+					sum += s.Weight
+				}
+			}
+			servers = tmpServers
+		}
 
 		for si := 0; si < max; si++ {
 			n := rand.Intn(sum + 1)

--- a/serve.go
+++ b/serve.go
@@ -81,7 +81,7 @@ func serve(w dns.ResponseWriter, req *dns.Msg, z *Zone) {
 		ip = realIP
 	}
 
-	targets, netmask := z.Options.Targeting.GetTargets(ip)
+	targets, netmask, location := z.Options.Targeting.GetTargets(ip, z.HasClosest)
 
 	m := new(dns.Msg)
 	m.SetReply(req)
@@ -133,9 +133,14 @@ func serve(w dns.ResponseWriter, req *dns.Msg, z *Zone) {
 					ip.String(),
 				}
 
-				targets, netmask := z.Options.Targeting.GetTargets(ip)
+				targets, netmask, location := z.Options.Targeting.GetTargets(ip, z.HasClosest)
 				txt = append(txt, strings.Join(targets, " "))
 				txt = append(txt, fmt.Sprintf("/%d", netmask), serverID, serverIP)
+				if location != nil {
+					txt = append(txt, fmt.Sprintf("(%.3f,%.3f)", location.latitude, location.longitude))
+				} else {
+					txt = append(txt, "(?,?)")
+				}
 
 				m.Answer = []dns.RR{&dns.TXT{Hdr: h,
 					Txt: txt,
@@ -159,7 +164,11 @@ func serve(w dns.ResponseWriter, req *dns.Msg, z *Zone) {
 		return
 	}
 
-	if servers := labels.Picker(labelQtype, labels.MaxHosts); servers != nil {
+	if !labels.Closest {
+		location = nil
+	}
+
+	if servers := labels.Picker(labelQtype, labels.MaxHosts, location); servers != nil {
 		var rrs []dns.RR
 		for _, record := range servers {
 			rr := dns.Copy(record.RR)

--- a/serve_test.go
+++ b/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	. "github.com/abh/geodns/Godeps/_workspace/src/gopkg.in/check.v1"
@@ -32,6 +33,9 @@ func (s *ServeSuite) SetUpSuite(c *C) {
 	// listenAndServe returns after listning on udp + tcp, so just
 	// wait for it before continuing
 	listenAndServe(PORT)
+
+	// ensure service has properly started before we query it
+	time.Sleep(200 * time.Millisecond)
 }
 
 func (s *ServeSuite) TestServing(c *C) {

--- a/targeting.go
+++ b/targeting.go
@@ -24,20 +24,19 @@ func init() {
 	cidr48Mask = net.CIDRMask(48, 128)
 }
 
-func (t TargetOptions) GetTargets(ip net.IP) ([]string, int) {
+func (t TargetOptions) GetTargets(ip net.IP, hasClosest bool) ([]string, int, *Location) {
 
 	targets := make([]string, 0)
 
 	var country, continent, region, regionGroup, asn string
 	var netmask int
+	var location *Location
 
 	if t&TargetASN > 0 {
 		asn, netmask = geoIP.GetASN(ip)
 	}
-
-	if t&TargetRegion > 0 || t&TargetRegionGroup > 0 {
-		country, continent, regionGroup, region, netmask = geoIP.GetCountryRegion(ip)
-
+	if t&TargetRegion > 0 || t&TargetRegionGroup > 0 || hasClosest {
+		country, continent, regionGroup, region, netmask, location = geoIP.GetCountryRegion(ip)
 	} else if t&TargetCountry > 0 || t&TargetContinent > 0 {
 		country, continent, netmask = geoIP.GetCountry(ip)
 	}
@@ -80,7 +79,7 @@ func (t TargetOptions) GetTargets(ip net.IP) ([]string, int) {
 	if t&TargetGlobal > 0 {
 		targets = append(targets, "@")
 	}
-	return targets, netmask
+	return targets, netmask, location
 }
 
 func (t TargetOptions) String() string {

--- a/targeting_test.go
+++ b/targeting_test.go
@@ -41,7 +41,7 @@ func (s *TargetingSuite) TestGetTargets(c *C) {
 	geoIP.setupGeoIPASN()
 
 	tgt, _ := parseTargets("@ continent country")
-	targets, _ := tgt.GetTargets(ip)
+	targets, _, _ := tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"us", "north-america", "@"})
 
 	if geoIP.city == nil {
@@ -50,20 +50,20 @@ func (s *TargetingSuite) TestGetTargets(c *C) {
 	}
 
 	tgt, _ = parseTargets("@ continent country region ")
-	targets, _ = tgt.GetTargets(ip)
+	targets, _, _ = tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"us-ca", "us", "north-america", "@"})
 
 	tgt, _ = parseTargets("@ continent regiongroup country region ")
-	targets, _ = tgt.GetTargets(ip)
+	targets, _, _ = tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"us-ca", "us-west", "us", "north-america", "@"})
 
 	tgt, _ = parseTargets("@ continent regiongroup country region asn ip")
-	targets, _ = tgt.GetTargets(ip)
+	targets, _, _ = tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"[207.171.1.1]", "[207.171.1.0]", "as7012", "us-ca", "us-west", "us", "north-america", "@"})
 
 	ip = net.ParseIP("2607:f238:2:0::ff:4")
 	tgt, _ = parseTargets("ip")
-	targets, _ = tgt.GetTargets(ip)
+	targets, _, _ = tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"[2607:f238:2::ff:4]", "[2607:f238:2::]"})
 
 }

--- a/zone.go
+++ b/zone.go
@@ -26,6 +26,7 @@ type Record struct {
 	RR     dns.RR
 	Weight int
 	Loc    *Location
+	Test   *HealthTest
 }
 
 type Records []Record
@@ -44,6 +45,7 @@ type Label struct {
 	Records  map[uint16]Records
 	Weight   map[uint16]int
 	Closest  bool
+	Test     *HealthTest
 }
 
 type labels map[string]*Label
@@ -111,6 +113,7 @@ func (z *Zone) SetupMetrics(old *Zone) {
 }
 
 func (z *Zone) Close() {
+	z.StartStopHealthChecks(false, nil)
 	z.Metrics.Registry.UnregisterAll()
 	if z.Metrics.LabelStats != nil {
 		z.Metrics.LabelStats.Close()

--- a/zone.go
+++ b/zone.go
@@ -14,6 +14,7 @@ type ZoneOptions struct {
 	MaxHosts  int
 	Contact   string
 	Targeting TargetOptions
+	Closest   bool
 }
 
 type ZoneLogging struct {
@@ -24,6 +25,7 @@ type ZoneLogging struct {
 type Record struct {
 	RR     dns.RR
 	Weight int
+	Loc    *Location
 }
 
 type Records []Record
@@ -41,6 +43,7 @@ type Label struct {
 	Ttl      int
 	Records  map[uint16]Records
 	Weight   map[uint16]int
+	Closest  bool
 }
 
 type labels map[string]*Label
@@ -60,7 +63,7 @@ type Zone struct {
 	Options    ZoneOptions
 	Logging    *ZoneLogging
 	Metrics    ZoneMetrics
-
+	HasClosest bool
 	sync.RWMutex
 }
 
@@ -128,6 +131,7 @@ func (z *Zone) AddLabel(k string) *Label {
 	label.Label = k
 	label.Ttl = 0 // replaced later
 	label.MaxHosts = z.Options.MaxHosts
+	label.Closest = z.Options.Closest
 
 	label.Records = make(map[uint16]Records)
 	label.Weight = make(map[uint16]int)
@@ -184,4 +188,28 @@ func (z *Zone) findLabels(s string, targets []string, qts qTypes) (*Label, uint1
 	}
 
 	return z.Labels[s], 0
+}
+
+// Find the locations of all the A records within a zone. If we were being really clever
+// here we could use LOC records too. But for the time being we'll just use GeoIP
+
+func (z *Zone) SetLocations() {
+	qtypes := []uint16{dns.TypeA}
+	for _, label := range z.Labels {
+		if label.Closest {
+			for _, qtype := range qtypes {
+				if label.Records[qtype] != nil && len(label.Records[qtype]) > 0 {
+					for i := range label.Records[qtype] {
+						label.Records[qtype][i].Loc = nil
+						rr := label.Records[qtype][i].RR
+						if a, ok := rr.(*dns.A); ok {
+							ip := a.A
+							_, _, _, _, _, location := geoIP.GetCountryRegion(ip)
+							label.Records[qtype][i].Loc = location
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/zone.go
+++ b/zone.go
@@ -126,7 +126,7 @@ func (z *Zone) AddLabel(k string) *Label {
 	z.Labels[k] = new(Label)
 	label := z.Labels[k]
 	label.Label = k
-	label.Ttl = z.Options.Ttl
+	label.Ttl = 0 // replaced later
 	label.MaxHosts = z.Options.MaxHosts
 
 	label.Records = make(map[uint16]Records)


### PR DESCRIPTION
Add a RR which returns the health status of a record, for debugging purposes. This returns in JSON format the health record of all the records associated with a label if a health test is running.

Example follows.

```
$ dig -p 10053 TXT _health.foo.example2.com @127.0.0.1

; <<>> DiG 9.8.3-P1 <<>> -p 10053 TXT _health.foo.example2.com @127.0.0.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 59545
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;_health.foo.example2.com.  IN      TXT

;; ANSWER SECTION:
_health.foo.example2.com. 1 IN      TXT     "{\"A\":{\"192.168.1.2\":false,\"192.168.1.3\":false,\"192.168.1.4\":false},\"AAAA\":{\"fd06:c1d3:e902:202:a5ff:fecd:13a6:a\":false,\"fd06:c1d3:e902::2\":false,\"fd06:c1d3:e902::4\":false}}"

;; Query time: 1 msec
;; SERVER: 127.0.0.1#10053(127.0.0.1)
;; WHEN: Wed Sep  2 19:24:01 2015
;; MSG SIZE  rcvd: 251
```

Decoding that JSON:

```
{
   "A" : {
      "192.168.1.4" : false,
      "192.168.1.3" : false,
      "192.168.1.2" : false
   },
   "AAAA" : {
      "fd06:c1d3:e902:202:a5ff:fecd:13a6:a" : false,
      "fd06:c1d3:e902::4" : false,
      "fd06:c1d3:e902::2" : false
   }
}
```
