### PR TITLE
Skip unchanged zonefiles

### DIFF
--- a/geodns.go
+++ b/geodns.go
@@ -141,8 +141,6 @@ func main() {
 	metrics := NewMetrics()
 	go metrics.Updater()
 
-	go statHatPoster()
-
 	if *flaginter == "*" {
 		addrs, _ := net.InterfaceAddrs()
 		ips := make([]string, 0)
@@ -160,6 +158,8 @@ func main() {
 	}
 
 	inter := getInterfaces()
+
+	go statHatPoster()
 
 	Zones := make(Zones)
 

--- a/geodns.go
+++ b/geodns.go
@@ -54,6 +54,7 @@ var (
 	flaghttp        = flag.String("http", ":8053", "http listen address (:8053)")
 	flaglog         = flag.Bool("log", false, "be more verbose")
 	flagcpus        = flag.Int("cpus", 1, "Set the maximum number of CPUs to use")
+	flagLogTo       = flag.String("logto", "", "log to file")
 
 	flagShowVersion = flag.Bool("version", false, "Show dnsconfig version")
 
@@ -80,6 +81,10 @@ func main() {
 	if *flagShowVersion {
 		fmt.Println("geodns", VERSION, buildTime)
 		os.Exit(0)
+	}
+
+	if flagLogTo != nil && *flagLogTo != "" {
+		logToFile(*flagLogTo)
 	}
 
 	if len(*flagidentifier) > 0 {
@@ -190,5 +195,5 @@ func main() {
 		pprof.WriteHeapProfile(f)
 		f.Close()
 	}
-
+	logClose()
 }

--- a/geoip.go
+++ b/geoip.go
@@ -81,8 +81,9 @@ func (g *GeoIP) GetASN(ip net.IP) (asn string, netmask int) {
 }
 
 func (g *GeoIP) setDirectory() {
-	if len(Config.GeoIP.Directory) > 0 {
-		geoip.SetCustomDirectory(Config.GeoIP.Directory)
+	directory := Config.GeoIPDirectory()
+	if len(directory) > 0 {
+		geoip.SetCustomDirectory(directory)
 	}
 }
 

--- a/heathtest.go
+++ b/heathtest.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
+	"math/rand"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+)
+
+var (
+	healthQtypes = []uint16{dns.TypeA, dns.TypeAAAA}
+)
+
+type HealthTester interface {
+	Test(ht *HealthTest) bool
+}
+
+type TcpHealthTester struct {
+	port int
+}
+
+type NtpHealthTester struct {
+	maxStratum int
+}
+
+type HealthTestParameters struct {
+	frequency        time.Duration
+	retryTime        time.Duration
+	timeout          time.Duration
+	retries          int
+	healthyInitially bool
+}
+
+type HealthTest struct {
+	HealthTestParameters
+	ipAddress    net.IP
+	healthy      bool
+	healthyMutex sync.RWMutex
+	closing      chan chan error
+	health       chan bool
+	tester       *HealthTester
+}
+
+func defaultHealthTestParameters() HealthTestParameters {
+	return HealthTestParameters{
+		frequency:        30 * time.Second,
+		retryTime:        5 * time.Second,
+		timeout:          5 * time.Second,
+		retries:          3,
+		healthyInitially: false,
+	}
+}
+
+func newHealthTest(ipAddress net.IP, htp HealthTestParameters, tester *HealthTester) *HealthTest {
+	ht := HealthTest{
+		ipAddress:            ipAddress,
+		HealthTestParameters: htp,
+		healthy:              true,
+		tester:               tester,
+	}
+	ht.healthy = ht.healthyInitially
+	if ht.frequency < time.Second {
+		ht.frequency = time.Second
+	}
+	if ht.retryTime < time.Second {
+		ht.retryTime = time.Second
+	}
+	if ht.timeout < time.Second {
+		ht.timeout = time.Second
+	}
+	return &ht
+}
+
+// safe copy function that copies the parameters but not (e.g.) the
+// mutex
+func (ht *HealthTest) copy(ipAddress net.IP) *HealthTest {
+	return newHealthTest(ipAddress, ht.HealthTestParameters, ht.tester)
+}
+
+func (ht *HealthTest) run() {
+	randomDelay := rand.Int63n(ht.frequency.Nanoseconds())
+	if !ht.isHealthy() {
+		randomDelay = rand.Int63n(ht.retryTime.Nanoseconds())
+	}
+	var nextPoll time.Time = time.Now().Add(time.Duration(randomDelay))
+	var pollStart time.Time
+	failCount := 0
+	for {
+		var pollDelay time.Duration
+		if now := time.Now(); nextPoll.After(now) {
+			pollDelay = nextPoll.Sub(now)
+		}
+		var startPoll <-chan time.Time
+		if pollStart.IsZero() {
+			startPoll = time.After(pollDelay)
+		}
+		select {
+		case errc := <-ht.closing:
+			errc <- nil
+			return
+		case <-startPoll:
+			pollStart = time.Now()
+			go ht.poll()
+		case h := <-ht.health:
+			nextPoll = pollStart.Add(ht.frequency)
+			if h {
+				ht.setHealthy(true)
+				failCount = 0
+			} else {
+				failCount++
+				logPrintf("Failure for %s, retry count=%d, healthy=%v", ht.ipAddress, failCount, ht.isHealthy())
+				if failCount >= ht.retries {
+					ht.setHealthy(false)
+					nextPoll = pollStart.Add(ht.retryTime)
+				}
+			}
+			pollStart = time.Time{}
+			logPrintf("Check result for %s health=%v, next poll at %s", ht.ipAddress, h, nextPoll)
+			//randomDelay := rand.Int63n(time.Second.Nanoseconds())
+			//nextPoll = nextPoll.Add(time.Duration(randomDelay))
+		}
+	}
+}
+
+func (ht *HealthTest) poll() {
+	logPrintf("Checking health of %s", ht.ipAddress)
+	result := (*ht.tester).Test(ht)
+	logPrintf("Checked health of %s, healthy=%v", ht.ipAddress, result)
+	ht.health <- result
+}
+
+func (ht *HealthTest) start() {
+	ht.closing = make(chan chan error)
+	ht.health = make(chan bool)
+	logPrintf("Starting health test on %s, frequency=%s, retry_time=%s, timeout=%s, retries=%d", ht.ipAddress, ht.frequency, ht.retryTime, ht.timeout, ht.retries)
+	go ht.run()
+}
+
+func (ht *HealthTest) stop() (err error) {
+	// Check it's been started by existing of the closing channel
+	if ht.closing == nil {
+		return nil
+	}
+	logPrintf("Stopping health test on %s", ht.ipAddress)
+	errc := make(chan error)
+	ht.closing <- errc
+	err = <-errc
+	close(ht.closing)
+	ht.closing = nil
+	close(ht.health)
+	ht.health = nil
+	return err
+}
+
+func (ht *HealthTest) isHealthy() bool {
+	ht.healthyMutex.RLock()
+	h := ht.healthy
+	ht.healthyMutex.RUnlock()
+	return h
+}
+
+func (ht *HealthTest) setHealthy(h bool) {
+	ht.healthyMutex.Lock()
+	old := ht.healthy
+	ht.healthy = h
+	ht.healthyMutex.Unlock()
+	if old != h {
+		logPrintf("Changing health status of %s from %v to %v", ht.ipAddress, old, h)
+	}
+}
+
+func (t TcpHealthTester) Test(ht *HealthTest) bool {
+	if conn, err := net.DialTimeout("tcp", net.JoinHostPort(ht.ipAddress.String(), strconv.Itoa(t.port)), ht.timeout); err != nil {
+		return false
+	} else {
+		conn.Close()
+	}
+	return true
+}
+
+func (t NtpHealthTester) Test(ht *HealthTest) bool {
+	udpAddress, err := net.ResolveUDPAddr("udp", net.JoinHostPort(ht.ipAddress.String(), "123"))
+	if err != nil {
+		return false
+	}
+
+	data := make([]byte, 48)
+	data[0] = 4<<3 | 3 /* version 4, client mode */
+
+	conn, err := net.DialUDP("udp", nil, udpAddress)
+	if err != nil {
+		return false
+	}
+
+	defer conn.Close()
+
+	_, err = conn.Write(data)
+	if err != nil {
+		return false
+	}
+
+	conn.SetDeadline(time.Now().Add(ht.timeout))
+
+	_, err = conn.Read(data)
+	if err != nil {
+		return false
+	}
+
+	stratum := data[1]
+
+	if stratum == 0 || stratum > byte(t.maxStratum) {
+		return false
+	}
+
+	return true
+}
+
+func (z *Zone) newHealthTest(l *Label, data interface{}) {
+	// First safely get rid of any old test. As label tests
+	// should never run this should never be executed
+	if l.Test != nil {
+		l.Test.stop()
+		l.Test = nil
+	}
+
+	if data == nil {
+		return
+	}
+	if i, ok := data.(map[string]interface{}); ok {
+		if t, ok := i["type"]; ok {
+			ts := valueToString(t)
+			htp := defaultHealthTestParameters()
+			for k, v := range i {
+				switch k {
+				case "frequency":
+					htp.frequency = time.Duration(valueToInt(v)) * time.Second
+				case "retry_time":
+					htp.retryTime = time.Duration(valueToInt(v)) * time.Second
+				case "timeout":
+					htp.retryTime = time.Duration(valueToInt(v)) * time.Second
+				case "retries":
+					htp.retries = valueToInt(v)
+				case "healthy_initially":
+					htp.healthyInitially = valueToBool(v)
+					logPrintf("HealthyInitially for %s is %v", l.Label, htp.healthyInitially)
+				}
+			}
+			var h HealthTester
+			switch ts {
+			case "tcp":
+				port := 80
+				if v, ok := i["port"]; ok {
+					port = valueToInt(v)
+				}
+				h = TcpHealthTester{port: port}
+			case "ntp":
+				maxStratum := 3
+				if v, ok := i["max_stratum"]; ok {
+					maxStratum = valueToInt(v)
+				}
+				h = NtpHealthTester{maxStratum: maxStratum}
+			default:
+				return
+			}
+			l.Test = newHealthTest(nil, htp, &h)
+		}
+	}
+}
+
+func (z *Zone) StartStopHealthChecks(start bool, oldZone *Zone) {
+	logPrintf("Start/stop health checks on zone %s start=%v", z.Origin, start)
+	for labelName, label := range z.Labels {
+		for _, qtype := range healthQtypes {
+			if label.Records[qtype] != nil && len(label.Records[qtype]) > 0 {
+				for i := range label.Records[qtype] {
+					rr := label.Records[qtype][i].RR
+					var ip net.IP
+					switch rrt := rr.(type) {
+					case *dns.A:
+						ip = rrt.A
+					case *dns.AAAA:
+						ip = rrt.AAAA
+					default:
+						continue
+					}
+					var test *HealthTest
+					if start {
+						if test = label.Records[qtype][i].Test; test != nil {
+							// stop any old test
+							test.stop()
+						} else {
+							if ltest := label.Test; ltest != nil {
+								test = ltest.copy(ip)
+								label.Records[qtype][i].Test = test
+							}
+						}
+						if test != nil {
+							test.ipAddress = ip
+							// if we are given an oldzone, let's see if we can find the old RR and
+							// copy over the initial health state, rather than use the initial health
+							// state provided from the label. This helps to stop health state bouncing
+							// when a zone file is reloaded for a purposes unrelated to the RR
+							if oldZone != nil {
+								oLabel, ok := oldZone.Labels[labelName]
+								if ok {
+									if oLabel.Test != nil {
+										for i := range oLabel.Records[qtype] {
+											oRecord := oLabel.Records[qtype][i]
+											var oip net.IP
+											switch orrt := oRecord.RR.(type) {
+											case *dns.A:
+												oip = orrt.A
+											case *dns.AAAA:
+												oip = orrt.AAAA
+											default:
+												continue
+											}
+											if oip.Equal(ip) {
+												if oRecord.Test != nil {
+													h := oRecord.Test.isHealthy()
+													logPrintf("Carrying over previous health state for %s: %v", oRecord.Test.ipAddress, h)
+													// we know the test is stopped (as we haven't started it) so we can write
+													// without the mutex and avoid a misleading log message
+													test.healthy = h
+												}
+												break
+											}
+										}
+									}
+								}
+							}
+							test.start()
+						}
+					} else {
+						if test = label.Records[qtype][i].Test; test != nil {
+							test.stop()
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/log.go
+++ b/log.go
@@ -1,6 +1,26 @@
 package main
 
-import "log"
+import (
+	"log"
+	"os"
+	"time"
+)
+
+type LogToFile struct {
+	fn      string
+	file    *os.File
+	closing chan chan error
+}
+
+var ltf *LogToFile
+
+func newLogToFile(fn string) *LogToFile {
+	return &LogToFile{
+		fn:      fn,
+		file:    nil,
+		closing: make(chan chan error),
+	}
+}
 
 func logPrintf(format string, a ...interface{}) {
 	if *flaglog {
@@ -11,5 +31,58 @@ func logPrintf(format string, a ...interface{}) {
 func logPrintln(a ...interface{}) {
 	if *flaglog {
 		log.Println(a...)
+	}
+}
+
+func logToFileMonitor() {
+	for {
+		select {
+		case errc := <-ltf.closing:
+			if ltf.file != nil {
+				log.SetOutput(os.Stderr)
+				ltf.file.Close()
+				ltf.file = nil
+			}
+			errc <- nil
+			return
+		case <-time.After(time.Duration(5 * time.Second)):
+			if fi, err := os.Stat(ltf.fn); err != nil || fi.Size() == 0 {
+				// it has rotated - first check we can open the new file
+				if f, err := os.OpenFile(ltf.fn, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666); err == nil {
+					log.SetOutput(f)
+					log.Printf("Rotating log file")
+					ltf.file.Close()
+					ltf.file = f
+				}
+			}
+		}
+	}
+}
+
+func logToFile(fn string) {
+
+	ltf = newLogToFile(fn)
+
+	var err error
+	ltf.file, err = os.OpenFile(fn, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		log.Fatalf("Error writing log file: %v", err)
+	}
+	// we deliberately do not close logFile here, because we keep it open pretty much for ever
+
+	log.SetOutput(ltf.file)
+	log.Printf("Opening log file")
+
+	go logToFileMonitor()
+}
+
+func logClose() {
+	if ltf != nil {
+		log.Printf("Closing log file")
+		errc := make(chan error)
+		ltf.closing <- errc
+		_ = <-errc
+		close(ltf.closing)
+		ltf = nil
 	}
 }

--- a/picker.go
+++ b/picker.go
@@ -36,7 +36,7 @@ func (label *Label) Picker(qtype uint16, max int, location *Location) Records {
 			tmpServers := servers[:0]
 			sum = 0
 			for i, s := range servers {
-				if servers[i].Test == nil || servers[i].Test.isHealthy() {
+				if servers[i].Test == nil || healthTestRunner.isHealthy(servers[i].Test) {
 					tmpServers = append(tmpServers, s)
 					sum += s.Weight
 				}

--- a/picker.go
+++ b/picker.go
@@ -6,13 +6,13 @@ import (
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 )
 
-func (label *Label) Picker(qtype uint16, max int) Records {
+func (label *Label) Picker(qtype uint16, max int, location *Location) Records {
 
 	if qtype == dns.TypeANY {
 		var result []Record
 		for rtype := range label.Records {
 
-			rtypeRecords := label.Picker(rtype, max)
+			rtypeRecords := label.Picker(rtype, max, location)
 
 			tmpResult := make(Records, len(result)+len(rtypeRecords))
 
@@ -40,6 +40,59 @@ func (label *Label) Picker(qtype uint16, max int) Records {
 		copy(servers, labelRR)
 		result := make([]Record, max)
 		sum := label.Weight[qtype]
+
+		// Find the distance to each server, and find the servers that are
+		// closer to the querier than the max'th furthest server, or within
+		// 5% thereof. What this means in practice is that if we have a nearby
+		// cluster of servers that are close, they all get included, so load
+		// balancing works
+		if qtype == dns.TypeA && location != nil && max < rrCount {
+			// First we record the distance to each server
+			distances := make([]float64, rrCount)
+			for i, s := range servers {
+				distance := location.Distance(s.Loc)
+				distances[i] = distance
+			}
+
+			// though this looks like O(n^2), typically max is small (e.g. 2)
+			// servers often have the same geographic location
+			// and rrCount is pretty small too, so the gain of an
+			// O(n log n) sort is small.
+			chosen := 0
+			choose := make([]bool, rrCount)
+
+			for chosen < max {
+				// Determine the minimum distance of servers not yet chosen
+				minDist := location.MaxDistance()
+				for i, _ := range servers {
+					if !choose[i] && distances[i] <= minDist {
+						minDist = distances[i]
+					}
+				}
+				// The threshold for inclusion on the this pass is 5% more
+				// than the minimum distance
+				minDist = minDist * 1.05
+				// Choose all the servers within the distance
+				for i := range servers {
+					if !choose[i] && distances[i] <= minDist {
+						choose[i] = true
+						chosen++
+					}
+				}
+			}
+
+			// Now choose only the chosen servers, using filtering without allocation
+			// slice trick. Meanwhile recalculate the total weight
+			tmpServers := servers[:0]
+			sum = 0
+			for i, s := range servers {
+				if choose[i] {
+					tmpServers = append(tmpServers, s)
+					sum += s.Weight
+				}
+			}
+			servers = tmpServers
+		}
 
 		for si := 0; si < max; si++ {
 			n := rand.Intn(sum + 1)

--- a/serve.go
+++ b/serve.go
@@ -112,6 +112,20 @@ func serve(w dns.ResponseWriter, req *dns.Msg, z *Zone) {
 			return
 		}
 
+		if firstLabel == "_health" {
+			if qtype == dns.TypeANY || qtype == dns.TypeTXT {
+				baseLabel := strings.Join((strings.Split(label, "."))[1:], ".")
+				m.Answer = z.healthRR(label+"."+z.Origin+".", baseLabel)
+				m.Authoritative = true
+				w.WriteMsg(m)
+				return
+			}
+			m.Ns = append(m.Ns, z.SoaRR())
+			m.Authoritative = true
+			w.WriteMsg(m)
+			return
+		}
+
 		if firstLabel == "_country" {
 			if qtype == dns.TypeANY || qtype == dns.TypeTXT {
 				h := dns.RR_Header{Ttl: 1, Class: dns.ClassINET, Rrtype: dns.TypeTXT}
@@ -199,6 +213,31 @@ func statusRR(label string) []dns.RR {
 	status["qps1"] = fmt.Sprintf("%.4f", qCounter.Rate1())
 
 	js, err := json.Marshal(status)
+
+	return []dns.RR{&dns.TXT{Hdr: h, Txt: []string{string(js)}}}
+}
+
+func (z *Zone) healthRR(label string, baseLabel string) []dns.RR {
+	h := dns.RR_Header{Ttl: 1, Class: dns.ClassINET, Rrtype: dns.TypeTXT}
+	h.Name = label
+
+	health := make(map[string]map[string]bool)
+
+	if l, ok := z.Labels[baseLabel]; ok {
+		for qt, records := range l.Records {
+			if qts, ok := dns.TypeToString[qt]; ok {
+				hmap := make(map[string]bool)
+				for _, record := range records {
+					if record.Test != nil {
+						hmap[(*record.Test).ipAddress.String()] = (*record.Test).isHealthy()
+					}
+				}
+				health[qts] = hmap
+			}
+		}
+	}
+
+	js, _ := json.Marshal(health)
 
 	return []dns.RR{&dns.TXT{Hdr: h, Txt: []string{string(js)}}}
 }

--- a/stathat.go
+++ b/stathat.go
@@ -12,7 +12,7 @@ import (
 
 func (zs *Zones) statHatPoster() {
 
-	if len(Config.StatHat.ApiKey) == 0 {
+	if !Config.HasStatHat() {
 		return
 	}
 
@@ -40,17 +40,17 @@ func (zs *Zones) statHatPoster() {
 
 				apiKey := zone.Logging.StatHatAPI
 				if len(apiKey) == 0 {
-					apiKey = Config.StatHat.ApiKey
+					apiKey = Config.StatHatApiKey()
 				}
 				if len(apiKey) == 0 {
 					continue
 				}
-				stathat.PostEZCount("zone "+name+" queries~"+suffix, Config.StatHat.ApiKey, int(newCount))
+				stathat.PostEZCount("zone "+name+" queries~"+suffix, Config.StatHatApiKey(), int(newCount))
 
 				ednsCount := zone.Metrics.EdnsQueries.Count()
 				newEdnsCount := ednsCount - lastEdnsCounts[name]
 				lastEdnsCounts[name] = ednsCount
-				stathat.PostEZCount("zone "+name+" edns queries~"+suffix, Config.StatHat.ApiKey, int(newEdnsCount))
+				stathat.PostEZCount("zone "+name+" edns queries~"+suffix, Config.StatHatApiKey(), int(newEdnsCount))
 
 			}
 		}
@@ -68,7 +68,7 @@ func statHatPoster() {
 	for {
 		time.Sleep(60 * time.Second)
 
-		if !Config.Flags.HasStatHat {
+		if !Config.HasStatHat() {
 			log.Println("No stathat configuration")
 			continue
 		}
@@ -79,8 +79,8 @@ func statHatPoster() {
 		newQueries := current - lastQueryCount
 		lastQueryCount = current
 
-		stathat.PostEZCount("queries~"+suffix, Config.StatHat.ApiKey, int(newQueries))
-		stathat.PostEZValue("goroutines "+serverID, Config.StatHat.ApiKey, float64(runtime.NumGoroutine()))
+		stathat.PostEZCount("queries~"+suffix, Config.StatHatApiKey(), int(newQueries))
+		stathat.PostEZValue("goroutines "+serverID, Config.StatHatApiKey(), float64(runtime.NumGoroutine()))
 
 	}
 }

--- a/targeting.go
+++ b/targeting.go
@@ -24,20 +24,19 @@ func init() {
 	cidr48Mask = net.CIDRMask(48, 128)
 }
 
-func (t TargetOptions) GetTargets(ip net.IP) ([]string, int) {
+func (t TargetOptions) GetTargets(ip net.IP, hasClosest bool) ([]string, int, *Location) {
 
 	targets := make([]string, 0)
 
 	var country, continent, region, regionGroup, asn string
 	var netmask int
+	var location *Location
 
 	if t&TargetASN > 0 {
 		asn, netmask = geoIP.GetASN(ip)
 	}
-
-	if t&TargetRegion > 0 || t&TargetRegionGroup > 0 {
-		country, continent, regionGroup, region, netmask = geoIP.GetCountryRegion(ip)
-
+	if t&TargetRegion > 0 || t&TargetRegionGroup > 0 || hasClosest {
+		country, continent, regionGroup, region, netmask, location = geoIP.GetCountryRegion(ip)
 	} else if t&TargetCountry > 0 || t&TargetContinent > 0 {
 		country, continent, netmask = geoIP.GetCountry(ip)
 	}
@@ -80,7 +79,7 @@ func (t TargetOptions) GetTargets(ip net.IP) ([]string, int) {
 	if t&TargetGlobal > 0 {
 		targets = append(targets, "@")
 	}
-	return targets, netmask
+	return targets, netmask, location
 }
 
 func (t TargetOptions) String() string {

--- a/targeting_test.go
+++ b/targeting_test.go
@@ -41,7 +41,7 @@ func (s *TargetingSuite) TestGetTargets(c *C) {
 	geoIP.setupGeoIPASN()
 
 	tgt, _ := parseTargets("@ continent country")
-	targets, _ := tgt.GetTargets(ip)
+	targets, _, _ := tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"us", "north-america", "@"})
 
 	if geoIP.city == nil {
@@ -50,20 +50,20 @@ func (s *TargetingSuite) TestGetTargets(c *C) {
 	}
 
 	tgt, _ = parseTargets("@ continent country region ")
-	targets, _ = tgt.GetTargets(ip)
+	targets, _, _ = tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"us-ca", "us", "north-america", "@"})
 
 	tgt, _ = parseTargets("@ continent regiongroup country region ")
-	targets, _ = tgt.GetTargets(ip)
+	targets, _, _ = tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"us-ca", "us-west", "us", "north-america", "@"})
 
 	tgt, _ = parseTargets("@ continent regiongroup country region asn ip")
-	targets, _ = tgt.GetTargets(ip)
+	targets, _, _ = tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"[207.171.1.1]", "[207.171.1.0]", "as7012", "us-ca", "us-west", "us", "north-america", "@"})
 
 	ip = net.ParseIP("2607:f238:2:0::ff:4")
 	tgt, _ = parseTargets("ip")
-	targets, _ = tgt.GetTargets(ip)
+	targets, _, _ = tgt.GetTargets(ip, false)
 	c.Check(targets, DeepEquals, []string{"[2607:f238:2::ff:4]", "[2607:f238:2::]"})
 
 }

--- a/zone.go
+++ b/zone.go
@@ -25,6 +25,7 @@ type Record struct {
 	RR     dns.RR
 	Weight int
 	Loc    *Location
+	Test   *HealthTest
 }
 
 type Records []Record
@@ -43,6 +44,7 @@ type Label struct {
 	Records  map[uint16]Records
 	Weight   map[uint16]int
 	Closest  bool
+	Test     *HealthTest
 }
 
 type labels map[string]*Label
@@ -102,6 +104,7 @@ func (z *Zone) SetupMetrics(old *Zone) {
 }
 
 func (z *Zone) Close() {
+	z.StartStopHealthChecks(false, nil)
 	metrics.Unregister(z.Origin + " queries")
 	metrics.Unregister(z.Origin + " EDNS queries")
 	if z.Metrics.LabelStats != nil {

--- a/zone.go
+++ b/zone.go
@@ -80,12 +80,19 @@ func NewZone(name string) *Zone {
 func (z *Zone) SetupMetrics(old *Zone) {
 	if old != nil {
 		z.Metrics = old.Metrics
-	} else {
+	}
+	if z.Metrics.Queries == nil {
 		z.Metrics.Queries = metrics.NewMeter()
-		z.Metrics.EdnsQueries = metrics.NewMeter()
 		metrics.Register(z.Origin+" queries", z.Metrics.Queries)
+	}
+	if z.Metrics.EdnsQueries == nil {
+		z.Metrics.EdnsQueries = metrics.NewMeter()
 		metrics.Register(z.Origin+" EDNS queries", z.Metrics.EdnsQueries)
+	}
+	if z.Metrics.LabelStats == nil {
 		z.Metrics.LabelStats = NewZoneLabelStats(10000)
+	}
+	if z.Metrics.ClientStats == nil {
 		z.Metrics.ClientStats = NewZoneLabelStats(10000)
 	}
 }

--- a/zone.go
+++ b/zone.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"strings"
-	"time"
 
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/rcrowley/go-metrics"
@@ -58,7 +57,6 @@ type Zone struct {
 	LabelCount int
 	Options    ZoneOptions
 	Logging    *ZoneLogging
-	LastRead   time.Time
 	Metrics    ZoneMetrics
 }
 

--- a/zone.go
+++ b/zone.go
@@ -93,8 +93,12 @@ func (z *Zone) SetupMetrics(old *Zone) {
 func (z *Zone) Close() {
 	metrics.Unregister(z.Origin + " queries")
 	metrics.Unregister(z.Origin + " EDNS queries")
-	z.Metrics.LabelStats.Close()
-	z.Metrics.ClientStats.Close()
+	if z.Metrics.LabelStats != nil {
+		z.Metrics.LabelStats.Close()
+	}
+	if z.Metrics.ClientStats != nil {
+		z.Metrics.ClientStats.Close()
+	}
 }
 
 func (l *Label) firstRR(dnsType uint16) dns.RR {

--- a/zone_test.go
+++ b/zone_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func (s *ConfigSuite) TestExampleComZone(c *C) {
-	ex := s.zones["test.example.com"]
+	ex, ok := s.zones["test.example.com"]
+
+	c.Check(ok, Equals, true)
+	c.Check(ex, NotNil)
 
 	// test.example.com was loaded
 	c.Assert(ex.Labels, NotNil)

--- a/zones.go
+++ b/zones.go
@@ -176,6 +176,11 @@ func readZoneFile(zoneName, fileName string) (zone *Zone, zerr error) {
 			zone.Options.Contact = v.(string)
 		case "max_hosts":
 			zone.Options.MaxHosts = valueToInt(v)
+		case "closest":
+			zone.Options.Closest = v.(bool)
+			if zone.Options.Closest {
+				zone.HasClosest = true
+			}
 		case "targeting":
 			zone.Options.Targeting, err = parseTargets(v.(string))
 			if err != nil {
@@ -214,13 +219,17 @@ func readZoneFile(zoneName, fileName string) (zone *Zone, zerr error) {
 	//log.Println("IP", string(Zone.Regions["0.us"].IPv4[0].ip))
 
 	switch {
-	case zone.Options.Targeting >= TargetRegionGroup:
+	case zone.Options.Targeting >= TargetRegionGroup || zone.HasClosest:
 		geoIP.setupGeoIPCity()
 	case zone.Options.Targeting >= TargetContinent:
 		geoIP.setupGeoIPCountry()
 	}
 	if zone.Options.Targeting&TargetASN > 0 {
 		geoIP.setupGeoIPASN()
+	}
+
+	if zone.HasClosest {
+		zone.SetLocations()
 	}
 
 	return zone, nil
@@ -250,6 +259,12 @@ func setupZoneData(data map[string]interface{}, Zone *Zone) {
 			switch rType {
 			case "max_hosts":
 				label.MaxHosts = valueToInt(rdata)
+				continue
+			case "closest":
+				label.Closest = rdata.(bool)
+				if label.Closest {
+					Zone.HasClosest = true
+				}
 				continue
 			case "ttl":
 				label.Ttl = valueToInt(rdata)

--- a/zones.go
+++ b/zones.go
@@ -21,6 +21,8 @@ import (
 // Zones maps domain names to zone data
 type Zones map[string]*Zone
 
+var lastRead = map[string]time.Time{}
+
 func zonesReader(dirName string, zones Zones) {
 	for {
 		zonesReadDir(dirName, zones)
@@ -56,12 +58,14 @@ func zonesReadDir(dirName string, zones Zones) error {
 
 		seenZones[zoneName] = true
 
-		if zone, ok := zones[zoneName]; !ok || file.ModTime().After(zone.LastRead) {
+		if _, ok := lastRead[zoneName]; !ok || file.ModTime().After(lastRead[zoneName]) {
 			if ok {
 				logPrintf("Reloading %s\n", fileName)
 			} else {
 				logPrintf("Reading new file %s\n", fileName)
 			}
+
+			lastRead[zoneName] = file.ModTime()
 
 			//log.Println("FILE:", i, file, zoneName)
 			config, err := readZoneFile(zoneName, path.Join(dirName, fileName))
@@ -70,7 +74,6 @@ func zonesReadDir(dirName string, zones Zones) error {
 				log.Println(parseErr.Error())
 				continue
 			}
-			config.LastRead = file.ModTime()
 
 			addHandler(zones, zoneName, config)
 		}
@@ -84,6 +87,7 @@ func zonesReadDir(dirName string, zones Zones) error {
 			continue
 		}
 		log.Println("Removing zone", zone.Origin)
+		delete(lastRead, zoneName)
 		zone.Close()
 		dns.HandleRemove(zoneName)
 		delete(zones, zoneName)

--- a/zones.go
+++ b/zones.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -21,7 +23,12 @@ import (
 // Zones maps domain names to zone data
 type Zones map[string]*Zone
 
-var lastRead = map[string]time.Time{}
+type ZoneReadRecord struct {
+	time time.Time
+	hash string
+}
+
+var lastRead = map[string]*ZoneReadRecord{}
 
 func zonesReader(dirName string, zones Zones) {
 	for {
@@ -64,22 +71,53 @@ func zonesReadDir(dirName string, zones Zones) error {
 
 		seenZones[zoneName] = true
 
-		if _, ok := lastRead[zoneName]; !ok || file.ModTime().After(lastRead[zoneName]) {
+		if _, ok := lastRead[zoneName]; !ok || file.ModTime().After(lastRead[zoneName].time) {
+			modTime := file.ModTime()
 			if ok {
 				logPrintf("Reloading %s\n", fileName)
+				lastRead[zoneName].time = modTime
 			} else {
 				logPrintf("Reading new file %s\n", fileName)
+				lastRead[zoneName] = &ZoneReadRecord{time: modTime}
 			}
 
-			lastRead[zoneName] = file.ModTime()
+			filename := path.Join(dirName, fileName)
 
-			//log.Println("FILE:", i, file, zoneName)
-			config, err := readZoneFile(zoneName, path.Join(dirName, fileName))
+			// Check the sha256 of the file has not changed. It's worth an explanation of
+			// why there isn't a TOCTOU race here. Conceivably after checking whether the
+			// SHA has changed, the contents then change again before we actually load
+			// the JSON. This can occur in two situations:
+			//
+			// 1. The SHA has not changed when we read the file for the SHA, but then
+			//    changes before we process the JSON
+			//
+			// 2. The SHA has changed when we read the file for the SHA, but then changes
+			//    again before we process the JSON
+			//
+			// In circumstance (1) we won't reread the file the first time, but the subsequent
+			// change should alter the mtime again, causing us to reread it. This reflects
+			// the fact there were actually two changes.
+			//
+			// In circumstance (2) we have already reread the file once, and then when the
+			// contents are changed the mtime changes again
+			//
+			// Provided files are replaced atomically, this should be OK. If files are not
+			// replaced atomically we have other problems (e.g. partial reads).
+
+			sha256 := sha256File(filename)
+			if lastRead[zoneName].hash == sha256 {
+				logPrintf("Skipping new file %s as hash is unchanged\n", filename)
+				continue
+			}
+
+			config, err := readZoneFile(zoneName, filename)
 			if config == nil || err != nil {
 				parseErr = fmt.Errorf("Error reading zone '%s': %s", zoneName, err)
 				log.Println(parseErr.Error())
 				continue
 			}
+
+			(lastRead[zoneName]).hash = sha256
 
 			addHandler(zones, zoneName, config)
 		}
@@ -673,4 +711,14 @@ func valueToInt(v interface{}) (rv int) {
 
 func zoneNameFromFile(fileName string) string {
 	return fileName[0:strings.LastIndex(fileName, ".")]
+}
+
+func sha256File(fn string) string {
+	if data, err := ioutil.ReadFile(fn); err != nil {
+		return ""
+	} else {
+		hasher := sha256.New()
+		hasher.Write(data)
+		return hex.EncodeToString(hasher.Sum(nil))
+	}
 }

--- a/zones.go
+++ b/zones.go
@@ -32,8 +32,12 @@ func zonesReader(dirName string, zones Zones) {
 
 func addHandler(zones Zones, name string, config *Zone) {
 	oldZone := zones[name]
+	if oldZone != nil {
+		oldZone.StartStopHealthChecks(false, nil)
+	}
 	config.SetupMetrics(oldZone)
 	zones[name] = config
+	config.StartStopHealthChecks(true, oldZone)
 	dns.HandleFunc(name, setupServerFunc(config))
 }
 
@@ -268,6 +272,9 @@ func setupZoneData(data map[string]interface{}, Zone *Zone) {
 				continue
 			case "ttl":
 				label.Ttl = valueToInt(rdata)
+				continue
+			case "test":
+				Zone.newHealthTest(label, rdata)
 				continue
 			}
 

--- a/zones.go
+++ b/zones.go
@@ -50,7 +50,9 @@ func zonesReadDir(dirName string, zones Zones) error {
 
 	for _, file := range dir {
 		fileName := file.Name()
-		if !strings.HasSuffix(strings.ToLower(fileName), ".json") {
+		if !strings.HasSuffix(strings.ToLower(fileName), ".json") ||
+			strings.HasPrefix(path.Base(fileName), ".") ||
+			file.IsDir() {
 			continue
 		}
 

--- a/zones_test.go
+++ b/zones_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	. "github.com/abh/geodns/Godeps/_workspace/src/gopkg.in/check.v1"
@@ -22,7 +21,7 @@ var _ = Suite(&ConfigSuite{})
 
 func (s *ConfigSuite) SetUpSuite(c *C) {
 	s.zones = make(Zones)
-	lastRead = map[string]time.Time{}
+	lastRead = map[string]*ZoneReadRecord{}
 	zonesReadDir("dns", s.zones)
 }
 

--- a/zones_test.go
+++ b/zones_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	. "github.com/abh/geodns/Godeps/_workspace/src/gopkg.in/check.v1"
@@ -21,6 +22,7 @@ var _ = Suite(&ConfigSuite{})
 
 func (s *ConfigSuite) SetUpSuite(c *C) {
 	s.zones = make(Zones)
+	lastRead = map[string]time.Time{}
 	zonesReadDir("dns", s.zones)
 }
 


### PR DESCRIPTION
Do not reload zonefiles which are entirely unchanged as determined by SHA256 hash. In an environment where (e.g.) zones are PUT using a REST API the same zone may be delivered in a situation where it is entirely unchanged. In this circumstance is it useful to avoid reloading it.