### PR TITLE
Add option to make debugging queries private

### DIFF
--- a/geodns.go
+++ b/geodns.go
@@ -51,15 +51,16 @@ var (
 var timeStarted = time.Now()
 
 var (
-	flagconfig      = flag.String("config", "./dns/", "directory of zone files")
-	flagcheckconfig = flag.Bool("checkconfig", false, "check configuration and exit")
-	flagidentifier  = flag.String("identifier", "", "identifier (hostname, pop name or similar)")
-	flaginter       = flag.String("interface", "*", "set the listener address")
-	flagport        = flag.String("port", "53", "default port number")
-	flaghttp        = flag.String("http", ":8053", "http listen address (:8053)")
-	flaglog         = flag.Bool("log", false, "be more verbose")
-	flagcpus        = flag.Int("cpus", 1, "Set the maximum number of CPUs to use")
-	flagLogFile     = flag.String("logfile", "", "log to file")
+	flagconfig       = flag.String("config", "./dns/", "directory of zone files")
+	flagcheckconfig  = flag.Bool("checkconfig", false, "check configuration and exit")
+	flagidentifier   = flag.String("identifier", "", "identifier (hostname, pop name or similar)")
+	flaginter        = flag.String("interface", "*", "set the listener address")
+	flagport         = flag.String("port", "53", "default port number")
+	flaghttp         = flag.String("http", ":8053", "http listen address (:8053)")
+	flaglog          = flag.Bool("log", false, "be more verbose")
+	flagcpus         = flag.Int("cpus", 1, "Set the maximum number of CPUs to use")
+	flagLogFile      = flag.String("logfile", "", "log to file")
+	flagPrivateDebug = flag.Bool("privatedebug", false, "Make debugging queries accepted only on loopback")
 
 	flagShowVersion = flag.Bool("version", false, "Show dnsconfig version")
 


### PR DESCRIPTION
Add an option to make debugging queries private, meaning only accepted from the loopback address. The debugging queries  (i.e. `_status`, `_health` and possibly `_country`) contain information which may be either commercially sensitive or security sensitive. Therefore provide an option (`-privatedebug`) which if set does not return these unless the query comes from the loopback address.
