### PR TITLE
Remove minimum ns ttl

### DIFF
--- a/serve_test.go
+++ b/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	. "github.com/abh/geodns/Godeps/_workspace/src/gopkg.in/check.v1"
@@ -32,6 +33,9 @@ func (s *ServeSuite) SetUpSuite(c *C) {
 	// listenAndServe returns after listning on udp + tcp, so just
 	// wait for it before continuing
 	listenAndServe(PORT)
+
+	// ensure service has properly started before we query it
+	time.Sleep(200 * time.Millisecond)
 }
 
 func (s *ServeSuite) TestServing(c *C) {

--- a/zone.go
+++ b/zone.go
@@ -126,7 +126,7 @@ func (z *Zone) AddLabel(k string) *Label {
 	z.Labels[k] = new(Label)
 	label := z.Labels[k]
 	label.Label = k
-	label.Ttl = z.Options.Ttl
+	label.Ttl = 0 // replaced later
 	label.MaxHosts = z.Options.MaxHosts
 
 	label.Records = make(map[uint16]Records)


### PR DESCRIPTION
geodns adopted a seemingly arbitrary minimum TTL for NS records of 86400 seconds (one day). I can find no reason for this in the RFCs. Setting a lower TTL is useful e.g. when NS records are to be changed, for instance removal of a nameserver. This patch removes this arbitrary limit.
