### PR TITLE
Add delay to test start.

### DIFF
--- a/serve_test.go
+++ b/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	. "github.com/abh/geodns/Godeps/_workspace/src/gopkg.in/check.v1"
@@ -32,6 +33,9 @@ func (s *ServeSuite) SetUpSuite(c *C) {
 	// listenAndServe returns after listning on udp + tcp, so just
 	// wait for it before continuing
 	listenAndServe(PORT)
+
+	// ensure service has properly started before we query it
+	time.Sleep(200 * time.Millisecond)
 }
 
 func (s *ServeSuite) TestServing(c *C) {


### PR DESCRIPTION
Commit c86fbed741f51c20f4fd16b927f67cf82368869f tidied some things
up but also removed a 200ms delay. This appears to be necessary to
ensure the server has actually started before sending it queries.
This is causing some random failures on travis builds I think.

Signed-off-by: Alex Bligh <alex@alex.org.uk>