### PR TITLE
Add forwarder capability

### DIFF
--- a/geodns.go
+++ b/geodns.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/abh/geodns/Godeps/_workspace/src/github.com/miekg/dns"
 	"github.com/abh/geodns/Godeps/_workspace/src/github.com/pborman/uuid"
 )
 
@@ -61,6 +62,7 @@ var (
 	flagcpus         = flag.Int("cpus", 1, "Set the maximum number of CPUs to use")
 	flagLogFile      = flag.String("logfile", "", "log to file")
 	flagPrivateDebug = flag.Bool("privatedebug", false, "Make debugging queries accepted only on loopback")
+	flagForwarder    = flag.String("forwarder", "", "forwarder address in the form ip:port defaults to ''")
 
 	flagShowVersion = flag.Bool("version", false, "Show dnsconfig version")
 
@@ -187,6 +189,12 @@ func main() {
 
 	dirName := *flagconfig
 	go zonesReader(dirName, Zones)
+
+	if *flagForwarder != "" {
+		log.Println("Activating forwarder", *flagForwarder)
+		// forward all zone requests we are not aware of...
+		dns.HandleFunc(".", proxy)
+	}
 
 	for _, host := range inter {
 		go listenAndServe(host)

--- a/zones.go
+++ b/zones.go
@@ -41,7 +41,6 @@ func addHandler(zones Zones, name string, config *Zone) {
 	oldZone := zones[name]
 	config.SetupMetrics(oldZone)
 	zones[name] = config
-	log.Println("Setting up handler for zone", name)
 	dns.HandleFunc(name, setupServerFunc(config))
 }
 


### PR DESCRIPTION
Hi there,

I added a simplistic forwarder support and I would like to discuss of its usefulness and design with you. This is by no way a final implementation.

My aim through this PR and the previous one is to be able to use geodns as a DNS server for internal networks. This kind of use case obviously needs forwarding (more than geocoding)

If you are interested in this allowing me to support this use case I think I'll need to implement caching for the forwarded request (using the TTL as an expiration timer) to improve performance and lower the burden on the upstream DNS.

What do you think?
