### PR TITLE
feat: docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+.idea/
+vendor/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ docker-test: .PHONY
 		golang:1.14-alpine3.11 -- \
 		go test ./...
 
+docker-build: .PHONY
+	docker build --build-arg REVISION=`git rev-parse --short=5  HEAD` -t geodns .
+
 devel:
 	go build -tags devel
 


### PR DESCRIPTION
Docker image build with multi-stage and save build time.
Some code in `Dockerfile` is useless, such as

```diff
Dockerfile:
-ADD applog/ applog/
-ADD countries/ countries/
-ADD geodns-logs/ geodns-logs/
-ADD health/ health/
-ADD monitor/ monitor/
-ADD querylog/ querylog/
-ADD server/ server/
-ADD targeting/ targeting/
-ADD typeutil/ typeutil/
-ADD zones/ zones/
-ADD service/ service/
-ADD service-logs/ service-logs/
-ADD *.go build ./

+COPY . /goapp
```
There is no need to add code one by one. Use `.dockerignore` then one *COPY* .

```diff
Dockerfile:
+FROM golang as prepare
+COPY go.mod go.sum /goapp/
+WORKDIR /goapp/
+RUN go mod download

-ADD vendor/ vendor/

.dockerignore:
+.git/
+.idea/
+vendor/
+dist/

```
This change because `vendor/` not always same in any OS system. Use stage `prepare` to download packages can save time.

## Build Docker image

    make docker-build

